### PR TITLE
Update os-compatibility-matrix-hana-large-instance.md

### DIFF
--- a/articles/virtual-machines/workloads/sap/os-compatibility-matrix-hana-large-instance.md
+++ b/articles/virtual-machines/workloads/sap/os-compatibility-matrix-hana-large-instance.md
@@ -44,6 +44,7 @@ ms.custom: H1Hack27Feb2017
   | SLES 12 SP5             | Available           | S384, S384m, S384xm, S384xxm, S576m, S576xm, S768m, S768xm, S896m, S960m |
   | SLES 15 SP1             | Available           | S384, S384m, S384xm, S384xxm, S576m, S576xm, S768m, S768xm, S896m, S960m |
   | RHEL 7.6                | Available           | S384, S384m, S384xm, S384xxm, S576m, S576xm, S768m, S768xm, S896m, S960m |
+  | RHEL 7.9                | Available           | S384, S384m, S384xm, S384xxm, S576m, S576xm, S768m, S768xm, S896m, S960m |
 
 ## Next steps
 


### PR DESCRIPTION
Adding RHEL 7.9 in supported OS for HLI type-2